### PR TITLE
 Define properties for destructor behaviour

### DIFF
--- a/P0737_ExecContext.rst
+++ b/P0737_ExecContext.rst
@@ -188,7 +188,7 @@ Minimal *Concept* Specification
   using query_member_result_t = typename query_member_result<ExecutionContext,
     Property>::type;
 
-  // Directionality properties:
+  // On destruction properties:
 
   constexpr struct abandon_on_destruction_t {} abandon_on_destruction;
   constexpr struct stop_on_destruction_t {} stop_on_destruction;

--- a/P0737_ExecContext.rst
+++ b/P0737_ExecContext.rst
@@ -321,10 +321,11 @@ Let ``EC`` be an *ExecutionContext* type.
       executing work and abort work which has not yet started executing. Any
       subsequent work which is submitted will be rejected.
     - If ``wait_on_destruction`` is true the ``EC`` will wait for all incomplete
-      work to be executed. If ``wait_on_outstanding_work_t`` is true the ``EC``
+      work to be executed. If ``wait_on_outstanding_work`` is true the ``EC``
       will also wait while the executor property ``outstanding_work`` is true
-      for any executors associated with ``EC``, otherwise any subsequent work
-      which is submitted will be rejected.
+      for any executors associated with ``EC`` and for any work submitted to
+      said executor(s) to complete, otherwise any subsequent work which is
+      submitted will be rejected.
 
 | ``template< class ExecutionContextProperty >``
 | ``query_member_result_t<ExecutionContext, Property> EC::query( ExecutionContextProperty p );``

--- a/P0737_ExecContext.rst
+++ b/P0737_ExecContext.rst
@@ -318,7 +318,7 @@ Let ``EC`` be an *ExecutionContext* type.
       is currently executing and all work that has not yet started executing.
       Any subsequent work which is submitted will be rejected.
     - If ``stop_on_destruction`` is true the ``EC`` will wait for all currently
-      executing work and cancel work which has not yet started executing. Any
+      executing work and abort work which has not yet started executing. Any
       subsequent work which is submitted will be rejected.
     - If ``wait_on_destruction`` is true the ``EC`` will wait for all incomplete
       work to be executed. If ``wait_on_outstanding_work_t`` is true the ``EC``

--- a/P0737_ExecContext.rst
+++ b/P0737_ExecContext.rst
@@ -315,16 +315,16 @@ Let ``EC`` be an *ExecutionContext* type.
   ``wait_on_destruction```.
 
     - If ``abandon_on_destruction`` is true the ``EC`` will abort all work that
-    is currently executing and all work that has not yet started executing. Any
-    subsequent work which is submitted will be rejected.
+      is currently executing and all work that has not yet started executing.
+      Any subsequent work which is submitted will be rejected.
     - If ``stop_on_destruction`` is true the ``EC`` will wait for all currently
-    executing work and cancel work which has not yet started executing. Any
-    subsequent work which is submitted will be rejected.
+      executing work and cancel work which has not yet started executing. Any
+      subsequent work which is submitted will be rejected.
     - If ``wait_on_destruction`` is true the ``EC`` will wait for all incomplete
-    work to be executed. If ``wait_on_outstanding_work_t`` is true the ``EC``
-    will also wait while the executor property ``outstanding_work`` is true for
-    any executors associated with ``EC``, otherwise any subsequent work which is
-    submitted will be rejected.
+      work to be executed. If ``wait_on_outstanding_work_t`` is true the ``EC``
+      will also wait while the executor property ``outstanding_work`` is true
+      for any executors associated with ``EC``, otherwise any subsequent work
+      which is submitted will be rejected.
 
 | ``template< class ExecutionContextProperty >``
 | ``query_member_result_t<ExecutionContext, Property> EC::query( ExecutionContextProperty p );``


### PR DESCRIPTION
**Summary**

During the executors call were discussing the outstanding work properties and how they would interact with an execution context. We decided that the outstanding work properties for the executor would act as a hint to the associated execution context which instructs it that there is outstanding work and such it should potentially alter it's destruction behaviour. However whether or not the execution context can honour this hint is up to the execution context implementation. We also discussed that it would be beneficial for the execution context to have a query interface, like that of executors to allow users to reason about an execution context's destruction and outstanding work behaviour.

This pull request proposes the addition of a `query` interface like that of the executors proposal, properties for querying an execution context's destruction and outstanding work behaviour, and to define the execution context destructor based on those properties.

**Changes**

* Introduce query interface for querying properties of the execution
context.
* Add properties for specifying the on destruction behaviour and
outstanding work capability.
* Update destructor definition to use on destruction properties.